### PR TITLE
migrate to new Java SDK

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>Bridge-Reporter</artifactId>
-    <version>1.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -62,8 +62,8 @@
         </dependency>
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
-            <artifactId>java-sdk</artifactId>
-            <version>0.11.6</version>
+            <artifactId>rest-client</artifactId>
+            <version>0.12.14</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
@@ -188,10 +188,6 @@
                         </goals>
                     </execution>
                 </executions>
-            </plugin>
-            <plugin>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-maven-plugin</artifactId>
             </plugin>
         </plugins>
         <extensions>

--- a/src/main/java/org/sagebionetworks/bridge/reporter/helper/BridgeHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/reporter/helper/BridgeHelper.java
@@ -1,93 +1,52 @@
 package org.sagebionetworks.bridge.reporter.helper;
 
+import java.io.IOException;
+import java.util.List;
+
 import org.joda.time.DateTime;
-import org.sagebionetworks.bridge.sdk.ClientProvider;
-import org.sagebionetworks.bridge.sdk.Session;
-import org.sagebionetworks.bridge.sdk.exceptions.NotAuthenticatedException;
-import org.sagebionetworks.bridge.sdk.models.ResourceList;
-import org.sagebionetworks.bridge.sdk.models.accounts.SignInCredentials;
-import org.sagebionetworks.bridge.sdk.models.reports.ReportData;
-import org.sagebionetworks.bridge.sdk.models.studies.StudySummary;
-import org.sagebionetworks.bridge.sdk.models.upload.Upload;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
+
+import org.sagebionetworks.bridge.rest.ClientManager;
+import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
+import org.sagebionetworks.bridge.rest.api.StudiesApi;
+import org.sagebionetworks.bridge.rest.model.ReportData;
+import org.sagebionetworks.bridge.rest.model.Study;
+import org.sagebionetworks.bridge.rest.model.Upload;
 
 /**
  * Helper to call Bridge Server to get information such as schemas. Also wraps some of the calls to provide caching.
  */
 @Component("ReporterHelper")
 public class BridgeHelper {
-    private static final Logger LOG = LoggerFactory.getLogger(BridgeHelper.class);
+    private ClientManager bridgeClientManager;
 
-    private SignInCredentials credentials;
-    private Session session = null;
-
-    /** Bridge credentials for the Exporter account. This needs to be saved in memory so we can refresh the session. */
+    /** Bridge Client Manager, with credentials for Exporter account. This is used to refresh the session. */
     @Autowired
-    final void setCredentials(SignInCredentials credentials) {
-        this.credentials = credentials;
+    public final void setBridgeClientManager(ClientManager bridgeClientManager) {
+        this.bridgeClientManager = bridgeClientManager;
     }
 
     /*
      * Helper method to get all studies summary as list from sdk
      */
-    public ResourceList<StudySummary> getAllStudiesSummary() {
-        return sessionHelper(() -> session.getStudyClient().getAllStudiesSummary());
+    public List<Study> getAllStudiesSummary() throws IOException {
+        return bridgeClientManager.getClient(StudiesApi.class).getStudies(true).execute().body().getItems();
     }
 
     /*
      * Helper method to get all uploads for specified study and date range
      */
-    public ResourceList<Upload> getUploadsForStudy(String studyId, DateTime startDateTime, DateTime endDateTime) {
-        return sessionHelper(() -> session.getWorkerClient().getUploadsForStudy(studyId, startDateTime, endDateTime));
+    public List<Upload> getUploadsForStudy(String studyId, DateTime startDateTime, DateTime endDateTime)
+            throws IOException {
+        return bridgeClientManager.getClient(ForWorkersApi.class).getUploadsInStudy(studyId, startDateTime,
+                endDateTime).execute().body().getItems();
     }
 
     /**
      * Helper method to save report for specified study with report id and report data
-     * @param studyId
-     * @param reportId
-     * @param reportData
      */
-    public void saveReportForStudy(String studyId, String reportId, ReportData reportData) {
-        sessionHelper(() -> {
-            session.getWorkerClient().saveReportForStudy(studyId, reportId, reportData);
-            return null;
-        });
-    }
-
-    // Helper method, which wraps a Bridge Server call with logic for initializing and refreshing a session.
-    private <T> T sessionHelper(BridgeCallable<T> callable) {
-        // Init session if necessary.
-        if (session == null) {
-            session = signIn();
-        }
-
-        // First attempt. This should be enough for most cases.
-        try {
-            return callable.call();
-        } catch (NotAuthenticatedException ex) {
-            // Code readability reasons, the error handling will be done after the catch block instead of inside the
-            // catch block.
-        }
-
-        // Refresh session and try again. This time, if the call fails, just let the exception bubble up.
-        LOG.info("Bridge server session expired. Refreshing session...");
-        session = signIn();
-        return callable.call();
-    }
-
-    // Helper method to sign in to Bridge Server and get a session. This needs to be wrapped because the sign-in call
-    // is static and therefore not mockable.
-    // Package-scoped to facilitate unit tests.
-    Session signIn() {
-        return ClientProvider.signIn(credentials);
-    }
-
-    // Functional interface used to make lambdas for the session helper.
-    @FunctionalInterface
-    interface BridgeCallable<T> {
-        T call();
+    public void saveReportForStudy(String studyId, String reportId, ReportData reportData) throws IOException {
+        bridgeClientManager.getClient(ForWorkersApi.class).saveReportForStudy(studyId, reportId, reportData).execute();
     }
 }

--- a/src/test/java/org/sagebionetworks/bridge/reporter/request/ReportScheduleNameTest.java
+++ b/src/test/java/org/sagebionetworks/bridge/reporter/request/ReportScheduleNameTest.java
@@ -1,7 +1,5 @@
 package org.sagebionetworks.bridge.reporter.request;
 
-import org.sagebionetworks.bridge.sdk.models.accounts.SharingScope;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;


### PR DESCRIPTION
The old Java SDK doesn't recognize upload status "duplicate", so we need to migrate to the new Java SDK (rest-client) to pick up changes to the Bridge model. (There are also other benefits to using the most up-to-date Java SDK.)

This also requires some code changes, as Jackson and GSON are not mutually cross-compatible. Instead of creating the report as a Jackson JSON node, we're now creating it as a Java Map.

Testing done:
* mvn verify (unit tests, findbugs, jacoco test coverage)
* manually tested by pulling into local WorkerPlatform

This depends on https://github.com/Sage-Bionetworks/BridgeJavaSDK/pull/355