### PR TITLE
add refresh session helper to BridgeHelper

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>org.sagebionetworks</groupId>
     <artifactId>Bridge-Reporter</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <packaging>jar</packaging>
 
     <properties>
@@ -63,7 +63,7 @@
         <dependency>
             <groupId>org.sagebionetworks.bridge</groupId>
             <artifactId>rest-client</artifactId>
-            <version>0.12.14</version>
+            <version>0.12.16</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>

--- a/src/main/java/org/sagebionetworks/bridge/reporter/config/SpringConfig.java
+++ b/src/main/java/org/sagebionetworks/bridge/reporter/config/SpringConfig.java
@@ -40,18 +40,18 @@ public class SpringConfig {
 
     @Bean
     public ClientManager bridgeClientManager() throws IOException {
-        // client info
         ClientInfo clientInfo = new ClientInfo().appName("BridgeReporter").appVersion(1);
+        return new ClientManager.Builder().withClientInfo(clientInfo).withSignIn(bridgeCredentials()).build();
+    }
 
+    @Bean
+    public SignIn bridgeCredentials() throws IOException {
         // sign-in credentials
         Config config = bridgeConfig();
         String study = config.get("bridge.worker.study");
         String email = config.get("bridge.worker.email");
         String password = config.get("bridge.worker.password");
-        SignIn signIn = new SignIn().study(study).email(email).password(password);
-
-        // client manager
-        return new ClientManager.Builder().withClientInfo(clientInfo).withSignIn(signIn).build();
+        return new SignIn().study(study).email(email).password(password);
     }
 
     @Bean

--- a/src/main/java/org/sagebionetworks/bridge/reporter/helper/BridgeHelper.java
+++ b/src/main/java/org/sagebionetworks/bridge/reporter/helper/BridgeHelper.java
@@ -4,13 +4,18 @@ import java.io.IOException;
 import java.util.List;
 
 import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import org.sagebionetworks.bridge.rest.ClientManager;
+import org.sagebionetworks.bridge.rest.api.AuthenticationApi;
 import org.sagebionetworks.bridge.rest.api.ForWorkersApi;
 import org.sagebionetworks.bridge.rest.api.StudiesApi;
+import org.sagebionetworks.bridge.rest.exceptions.NotAuthenticatedException;
 import org.sagebionetworks.bridge.rest.model.ReportData;
+import org.sagebionetworks.bridge.rest.model.SignIn;
 import org.sagebionetworks.bridge.rest.model.Study;
 import org.sagebionetworks.bridge.rest.model.Upload;
 
@@ -19,7 +24,10 @@ import org.sagebionetworks.bridge.rest.model.Upload;
  */
 @Component("ReporterHelper")
 public class BridgeHelper {
+    private static final Logger LOG = LoggerFactory.getLogger(BridgeHelper.class);
+
     private ClientManager bridgeClientManager;
+    private SignIn bridgeCredentials;
 
     /** Bridge Client Manager, with credentials for Exporter account. This is used to refresh the session. */
     @Autowired
@@ -27,11 +35,18 @@ public class BridgeHelper {
         this.bridgeClientManager = bridgeClientManager;
     }
 
+    /** Bridge credentials, used by the session helper to refresh the session. */
+    @Autowired
+    public final void setBridgeCredentials(SignIn bridgeCredentials) {
+        this.bridgeCredentials = bridgeCredentials;
+    }
+
     /*
      * Helper method to get all studies summary as list from sdk
      */
     public List<Study> getAllStudiesSummary() throws IOException {
-        return bridgeClientManager.getClient(StudiesApi.class).getStudies(true).execute().body().getItems();
+        return sessionHelper(() -> bridgeClientManager.getClient(StudiesApi.class).getStudies(true).execute().body()
+                .getItems());
     }
 
     /*
@@ -39,14 +54,38 @@ public class BridgeHelper {
      */
     public List<Upload> getUploadsForStudy(String studyId, DateTime startDateTime, DateTime endDateTime)
             throws IOException {
-        return bridgeClientManager.getClient(ForWorkersApi.class).getUploadsInStudy(studyId, startDateTime,
-                endDateTime).execute().body().getItems();
+        return sessionHelper(() -> bridgeClientManager.getClient(ForWorkersApi.class).getUploadsInStudy(studyId,
+                startDateTime, endDateTime).execute().body().getItems());
     }
 
     /**
      * Helper method to save report for specified study with report id and report data
      */
     public void saveReportForStudy(String studyId, String reportId, ReportData reportData) throws IOException {
-        bridgeClientManager.getClient(ForWorkersApi.class).saveReportForStudy(studyId, reportId, reportData).execute();
+        sessionHelper(() -> bridgeClientManager.getClient(ForWorkersApi.class).saveReportForStudy(studyId, reportId,
+                reportData).execute());
+    }
+
+    // Helper method, which wraps a Bridge Server call with logic for initializing and refreshing a session.
+    private <T> T sessionHelper(BridgeCallable<T> callable) throws IOException {
+        // First attempt. This should be enough for most cases.
+        try {
+            return callable.call();
+        } catch (NotAuthenticatedException ex) {
+            // Code readability reasons, the error handling will be done after the catch block instead of inside the
+            // catch block.
+        }
+
+        // Refresh session and try again. This time, if the call fails, just let the exception bubble up.
+        LOG.info("Bridge server session expired. Refreshing session...");
+        bridgeClientManager.getClient(AuthenticationApi.class).signIn(bridgeCredentials).execute();
+
+        return callable.call();
+    }
+
+    // Functional interface used to make lambdas for the session helper.
+    @FunctionalInterface
+    interface BridgeCallable<T> {
+        T call() throws IOException;
     }
 }


### PR DESCRIPTION
Add refresh session helper to BridgeHelper.

Testing done:
* mvn verify (unit tests, findbugs, jacoco test coverage)
* manually tested report, cleared session, then tested report again to verify refresh session

NOTE: This is slightly redundant with BridgeEX. See https://sagebionetworks.jira.com/browse/BRIDGE-1572